### PR TITLE
Resolve _attn_implementation error in new transformers version and improve model loading logic(from_pretrained)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,10 @@ setup(
     packages=find_packages(),
     install_requires=[
         "whisper_normalizer",
-        "huggingface_hub",
+        "huggingface_hub==0.34.3",
         "lulutils @ git+https://github.com/kehanlu/lulutils.git",
         "transformers>=4.49.0",
+        "safetensors",
         "peft",
     ],
     description='DeSTA2.5-Audio',


### PR DESCRIPTION
Resolve _attn_implementation error in new transformers version and improve model loading logic(from_pretrained).

It seems new transformers version will cause some errors in using `from_pretrained`.

1. Fix BERTConfig error
2. Refactor from_pretrained()